### PR TITLE
Added the capability to manipulate the "categories" attribute of calendar events.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ htmlcov/
 *.swp
 *.swo
 *~
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -62,12 +62,20 @@ claude
 ### Calendar Tools
 - **`list_events`** - List calendar events with details
 - **`get_event`** - Get specific event details
-- **`create_event`** - Create events with location and attendees
-- **`update_event`** - Reschedule or modify events
+- **`create_event`** - Create events with location, attendees, and categories
+- **`update_event`** - Reschedule or modify events including categories
 - **`delete_event`** - Cancel events
 - **`respond_event`** - Accept/decline/tentative response to invitations
 - **`check_availability`** - Check free/busy times for scheduling
 - **`search_events`** - Search calendar events
+
+### Category Tools
+- **`list_outlook_categories`** - List all outlook categories
+- **`create_outlook_category`** - Create new categories with colors
+- **`update_outlook_category_color`** - Update category colors
+- **`delete_outlook_category`** - Delete categories
+- **`get_outlook_category_by_name`** - Find category by display name
+- **`list_available_colors`** - List all available colors for categories
 
 ### Contact Tools
 - **`list_contacts`** - List all contacts

--- a/src/microsoft_mcp/tools.py
+++ b/src/microsoft_mcp/tools.py
@@ -580,11 +580,6 @@ def create_event(
     Use list_outlook_categories to see available categories, or create_outlook_category 
     to create new ones with natural language colors like 'red', 'blue', 'green', etc."""
     
-    # Validate and normalize categories parameter
-    if categories is None:
-        categories = []
-    elif not isinstance(categories, list):
-        categories = []
     
     event = {
         "subject": subject,

--- a/src/microsoft_mcp/tools.py
+++ b/src/microsoft_mcp/tools.py
@@ -572,7 +572,7 @@ def create_event(
     body: str | None = None,
     attendees: str | list[str] | None = None,
     timezone: str = "UTC",
-    categories: list[str] | None = None,
+    categories: str | list[str] | None = None,
 ) -> dict[str, Any]:
     """Create a calendar event with optional categories.
     
@@ -600,7 +600,8 @@ def create_event(
         ]
 
     if categories:
-        event["categories"] = categories
+        categories_list = [categories] if isinstance(categories, str) else categories
+        event["categories"] = categories_list
 
     result = graph.request("POST", "/me/events", account_id, json=event)
     if not result:


### PR DESCRIPTION
 ## Summary
  This PR adds category support in the microsoft-mcp server. My use case is getting Claude to assign named categories to calendar events with colors in Outlook.

  ## How to Test

  **Test Steps**
     - [ ] **Color Discovery**: `list_available_colors` → expect full color list
     - [ ] **Create Category**: `create_outlook_category("Administrative", "red")` → success confirmation
     - [ ] **Single Category Event**: Tomorrow 2 PM "Single Category Test" with "Administrative" → event appears with red category
     - [ ] **Multiple Categories During Creation**: Create event with `["Administrative", "Personal Tasks"]` → success (was failing before)
     - [ ] **Natural-Language Colors**: `create_outlook_category("Personal Tasks", "dark blue")` → success
     - [ ] **Multiple Categories Update**: Update existing event to include both categories → both show
     - [ ] **Event Listing**: `list_events` for this week → shows categorized events
     - [ ] **Error Handling**: Attempt `create_outlook_category("Test", "rainbow")` → helpful error listing valid colors
     - [ ] **Outlook Verification**: Confirm sync in Outlook UI

  ## Expected Results
  list_available_colors
  {"red": "Bright red", "dark blue": "Dark blue", ...}

  create_outlook_category("Administrative", "red"){"displayName": "Administrative", "color": "preset0", ...}

  create_event(..., categories=["Administrative", "Personal Tasks"])
  {"categories": ["Administrative", "Personal Tasks"], "_multiple_categories_method": "create_then_update", ...}

  ## Cleanup
  Events and categories can be deleted through Outlook UI or using `delete_event` function.