### PR TITLE
Fix MSAL account validation to prevent silent 15-minute hangs

### DIFF
--- a/src/microsoft_mcp/auth.py
+++ b/src/microsoft_mcp/auth.py
@@ -57,6 +57,13 @@ def get_token(account_id: str | None = None) -> str:
         account = next(
             (a for a in accounts if a["home_account_id"] == account_id), None
         )
+        if not account:
+            valid_ids = [a["home_account_id"] for a in accounts]
+            raise ValueError(
+                f"Account '{account_id}' not found in token cache. "
+                f"Use list_accounts to get valid account IDs. "
+                f"Valid accounts: {valid_ids}"
+            )
     elif accounts:
         account = accounts[0]
 


### PR DESCRIPTION
## Problem

When `account_id` is provided to `get_token()` but doesn't match any account in the token cache, the `next()` call returns `None`. Then `acquire_token_silent(SCOPES, account=None)` silently falls back to initiating a device code flow, causing a **15-minute hang** waiting for interactive authentication that never comes.

This commonly happens when:
- Token cache is cleared but the caller still has an old account_id
- Account_id is mistyped or from a different cache
- User passes an email address instead of the UUID account_id

## Fix

Add explicit validation after the account lookup. If `account_id` is provided but not found in the cache, raise `ValueError` with the list of valid account IDs instead of silently hanging.

## Changes

- `src/microsoft_mcp/auth.py`: Add account validation check in `get_token()`

## Testing

Tested by providing an invalid account_id — now raises immediately with a helpful error message instead of hanging for 15 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)