### PR TITLE
Add email categories support and configurable token cache path

### DIFF
--- a/src/microsoft_mcp/auth.py
+++ b/src/microsoft_mcp/auth.py
@@ -6,7 +6,12 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-CACHE_FILE = pl.Path.home() / ".microsoft_mcp_token_cache.json"
+CACHE_FILE = pl.Path(
+    os.getenv(
+        "MICROSOFT_MCP_TOKEN_CACHE",
+        str(pl.Path.home() / ".microsoft_mcp_token_cache.json"),
+    )
+)
 SCOPES = ["https://graph.microsoft.com/.default"]
 
 

--- a/src/microsoft_mcp/tools.py
+++ b/src/microsoft_mcp/tools.py
@@ -401,12 +401,30 @@ def send_email(
 
 @mcp.tool
 def update_email(
-    email_id: str, updates: dict[str, Any], account_id: str
+    email_id: str,
+    account_id: str,
+    updates: dict[str, Any] | None = None,
+    categories: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Update email properties (isRead, categories, flag, etc.)"""
-    result = graph.request(
-        "PATCH", f"/me/messages/{email_id}", account_id, json=updates
-    )
+    """Update email properties (isRead, categories, flag, etc.)
+
+    Args:
+        email_id: The email ID to update
+        account_id: The account ID
+        updates: Arbitrary property updates to pass to the Graph API
+            (e.g. {"isRead": true, "flag": {"flagStatus": "flagged"}})
+        categories: List of category names to assign to the email
+            (e.g. ["Blue category", "Red category"]).
+            Overrides any 'categories' key in updates if both are provided.
+    """
+    body: dict[str, Any] = dict(updates) if updates else {}
+    if categories is not None:
+        body["categories"] = categories
+
+    if not body:
+        raise ValueError("Nothing to update: provide updates and/or categories")
+
+    result = graph.request("PATCH", f"/me/messages/{email_id}", account_id, json=body)
     if not result:
         raise ValueError(f"Failed to update email {email_id} - no response")
     return result

--- a/tests/test_auth_cache_path.py
+++ b/tests/test_auth_cache_path.py
@@ -1,0 +1,26 @@
+import os
+import pathlib
+from unittest.mock import patch
+
+
+def test_cache_path_defaults_to_home_directory():
+    """Without env var, cache path should be ~/.microsoft_mcp_token_cache.json"""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("MICROSOFT_MCP_TOKEN_CACHE", None)
+        import importlib
+        from microsoft_mcp import auth
+
+        importlib.reload(auth)
+        expected = pathlib.Path.home() / ".microsoft_mcp_token_cache.json"
+        assert auth.CACHE_FILE == expected
+
+
+def test_cache_path_from_env_var():
+    """MICROSOFT_MCP_TOKEN_CACHE env var should override default path"""
+    custom_path = "/data/token_cache.json"
+    with patch.dict(os.environ, {"MICROSOFT_MCP_TOKEN_CACHE": custom_path}):
+        import importlib
+        from microsoft_mcp import auth
+
+        importlib.reload(auth)
+        assert auth.CACHE_FILE == pathlib.Path(custom_path)

--- a/tests/test_update_email_categories.py
+++ b/tests/test_update_email_categories.py
@@ -1,0 +1,102 @@
+"""Tests for categories support in update_email."""
+
+from unittest.mock import patch
+from microsoft_mcp.tools import update_email as _update_email_tool
+
+# FastMCP 2.8.0: @mcp.tool(name=...) wraps in FunctionTool; .fn is the raw callable
+update_email = _update_email_tool.fn
+
+
+@patch("microsoft_mcp.tools.graph.request")
+def test_categories_passed_in_patch_body(mock_request):
+    """When categories is provided, it should appear in the PATCH JSON body."""
+    mock_request.return_value = {"id": "msg-1", "categories": ["Blue category"]}
+
+    result = update_email(
+        email_id="msg-1",
+        account_id="acct-1",
+        categories=["Blue category"],
+    )
+
+    mock_request.assert_called_once_with(
+        "PATCH",
+        "/me/messages/msg-1",
+        "acct-1",
+        json={"categories": ["Blue category"]},
+    )
+    assert result["categories"] == ["Blue category"]
+
+
+@patch("microsoft_mcp.tools.graph.request")
+def test_categories_merged_with_updates(mock_request):
+    """categories param should merge with (and override) the updates dict."""
+    mock_request.return_value = {
+        "id": "msg-1",
+        "isRead": True,
+        "categories": ["Red category"],
+    }
+
+    result = update_email(
+        email_id="msg-1",
+        account_id="acct-1",
+        updates={"isRead": True, "categories": ["Old category"]},
+        categories=["Red category"],
+    )
+
+    # categories kwarg wins over updates dict
+    mock_request.assert_called_once_with(
+        "PATCH",
+        "/me/messages/msg-1",
+        "acct-1",
+        json={"isRead": True, "categories": ["Red category"]},
+    )
+    assert result["categories"] == ["Red category"]
+
+
+@patch("microsoft_mcp.tools.graph.request")
+def test_updates_without_categories(mock_request):
+    """When only updates is provided (no categories), it should work as before."""
+    mock_request.return_value = {"id": "msg-1", "isRead": False}
+
+    result = update_email(
+        email_id="msg-1",
+        account_id="acct-1",
+        updates={"isRead": False},
+    )
+
+    mock_request.assert_called_once_with(
+        "PATCH",
+        "/me/messages/msg-1",
+        "acct-1",
+        json={"isRead": False},
+    )
+    assert result["isRead"] is False
+
+
+@patch("microsoft_mcp.tools.graph.request")
+def test_empty_categories_list_clears_categories(mock_request):
+    """Passing an empty list should clear all categories on the message."""
+    mock_request.return_value = {"id": "msg-1", "categories": []}
+
+    result = update_email(
+        email_id="msg-1",
+        account_id="acct-1",
+        categories=[],
+    )
+
+    mock_request.assert_called_once_with(
+        "PATCH",
+        "/me/messages/msg-1",
+        "acct-1",
+        json={"categories": []},
+    )
+    assert result["categories"] == []
+
+
+def test_no_updates_and_no_categories_raises():
+    """Calling with neither updates nor categories should raise ValueError."""
+    try:
+        update_email(email_id="msg-1", account_id="acct-1")
+        assert False, "Expected ValueError"
+    except ValueError as e:
+        assert "Nothing to update" in str(e)


### PR DESCRIPTION
## Summary

Two small, related improvements:

1. **Email categories** — `update_email()` now accepts a `categories` parameter for directly assigning Outlook categories without needing to construct the raw Graph API payload
2. **Configurable token cache path** — New `MICROSOFT_MCP_TOKEN_CACHE` environment variable to override the default `~/.microsoft_mcp_token_cache.json` location

## Email Categories

```python
# Before: must know Graph API structure
update_email(email_id, account_id, updates={"categories": ["Blue category"]})

# After: dedicated parameter
update_email(email_id, account_id, categories=["Blue category"])
```

- `categories` parameter overrides any `categories` key in `updates` if both provided
- Pass empty list to clear all categories
- Backward compatible — existing `updates` dict still works

## Configurable Cache Path

```bash
# Default (unchanged)
~/.microsoft_mcp_token_cache.json

# Docker/container usage
export MICROSOFT_MCP_TOKEN_CACHE=/data/token_cache.json
```

Essential for container deployments where the home directory isn't persistent across restarts.

## Changes

- `src/microsoft_mcp/auth.py`: `CACHE_FILE` reads from env var with fallback to default
- `src/microsoft_mcp/tools.py`: `update_email()` accepts `categories` parameter
- `tests/test_auth_cache_path.py`: 2 tests for cache path configuration
- `tests/test_update_email_categories.py`: 5 tests for categories functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)