### PR TITLE
fix(auth): cast expires_in to string in authenticate_account

### DIFF
--- a/src/microsoft_mcp/tools.py
+++ b/src/microsoft_mcp/tools.py
@@ -57,7 +57,7 @@ def authenticate_account() -> dict[str, str]:
         "step4": "After authenticating, use the 'complete_authentication' tool to finish the process",
         "device_code": flow["user_code"],
         "verification_url": verification_url,
-        "expires_in": flow.get("expires_in", 900),
+        "expires_in": str(flow.get("expires_in", 900)),
         "_flow_cache": str(flow),
     }
 


### PR DESCRIPTION
## Problem

`authenticate_account` declares `dict[str, str]` as return type, but `expires_in` is returned as `int` from the MSAL device flow response. This causes an MCP output validation error:

```
Output validation error: 900 is not of type 'string'
```

This completely blocks authentication — the tool cannot be used at all.

## Fix

Wrap `expires_in` with `str()` on line 60 to match the declared return type.

## Testing

Tested manually via Claude Code MCP integration — authentication flow completes successfully after the fix.