### PR TITLE
feat(list_emails): add $filter parameter support

### DIFF
--- a/src/microsoft_mcp/tools.py
+++ b/src/microsoft_mcp/tools.py
@@ -162,11 +162,13 @@ def list_emails(
     params = {
         "$top": min(limit, 100),
         "$select": select_fields,
-        "$orderby": "receivedDateTime desc",
     }
 
     if filter:
+        # Personal accounts don't support $filter + $orderby on different fields
         params["$filter"] = filter
+    else:
+        params["$orderby"] = "receivedDateTime desc"
 
     emails = list(
         graph.request_paginated(

--- a/src/microsoft_mcp/tools.py
+++ b/src/microsoft_mcp/tools.py
@@ -135,8 +135,23 @@ def list_emails(
     folder: str = "inbox",
     limit: int = 10,
     include_body: bool = True,
+    filter: str | None = None,
 ) -> list[dict[str, Any]]:
-    """List emails from specified folder"""
+    """List emails from specified folder
+
+    Args:
+        account_id: The account ID
+        folder: Mail folder (inbox, sent, drafts, deleted, junk, archive)
+        limit: Maximum number of emails to return
+        include_body: Whether to include email body content
+        filter: OData $filter query string for filtering emails.
+            Examples:
+            - "from/emailAddress/address eq 'sender@example.com'"
+            - "subject eq 'Meeting Notes'"
+            - "receivedDateTime ge 2024-01-01"
+            - "hasAttachments eq true"
+            - "isRead eq false"
+    """
     folder_path = FOLDERS.get(folder.casefold(), folder)
 
     if include_body:
@@ -149,6 +164,9 @@ def list_emails(
         "$select": select_fields,
         "$orderby": "receivedDateTime desc",
     }
+
+    if filter:
+        params["$filter"] = filter
 
     emails = list(
         graph.request_paginated(


### PR DESCRIPTION
## Summary

- Add optional `filter` parameter to `list_emails` tool to support OData `$filter` queries
- Enables filtering emails by sender, subject, date, attachments, read status, etc.
- Particularly useful for **personal Microsoft accounts** where the `$search` API is not supported

## Motivation

The existing `search_emails` tool uses Microsoft's `/search/query` API, which returns a 400 error for personal accounts (@outlook.com, @hotmail.com). The `$filter` parameter on `/me/messages` endpoint works for both personal and work accounts, providing an alternative way to query emails.

## Usage Examples

```python
# Filter by sender
list_emails(account_id, filter="from/emailAddress/address eq 'sender@example.com'")

# Filter by date
list_emails(account_id, filter="receivedDateTime ge 2024-01-01")

# Filter by subject
list_emails(account_id, filter="subject eq 'Meeting Notes'")

# Filter unread emails with attachments
list_emails(account_id, filter="isRead eq false and hasAttachments eq true")
```

## Test plan

- [x] Tested with personal Microsoft account (@outlook.com)
- [x] Verified `$filter` by sender works
- [x] Verified `$filter` by date range works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)